### PR TITLE
update parsing for eve.json output

### DIFF
--- a/so-logstash/files/conf.d.so/1033_preprocess_snort.conf
+++ b/so-logstash/files/conf.d.so/1033_preprocess_snort.conf
@@ -12,7 +12,6 @@ filter {
                 }
                 mutate {
 		    rename => { "alert" => "orig_alert" } 
-		    rename => { "[orig_alert][action]" => "action" }
                     rename => { "[orig_alert][gid]" => "gid" }
                     rename => { "[orig_alert][signature_id]" => "sid" }
                     rename => { "[orig_alert][rev]" => "rev" }
@@ -53,7 +52,7 @@ filter {
         }
         if "eve" in [tags] {
           date {
-                match => [ "timestamp", "UNIX" ]
+                match => [ "timestamp", "ISO8601" ]
           }
         } else {
           date {


### PR DESCRIPTION
-Remove `action` field, as we do not support Suricata as an IPS
-Fix timestamp dateparsefailure